### PR TITLE
Improve script history options

### DIFF
--- a/Boop/Boop/AppDelegate.swift
+++ b/Boop/Boop/AppDelegate.swift
@@ -20,6 +20,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @IBOutlet weak var scriptManager: ScriptManager!
     @IBOutlet weak var editor: SyntaxTextView!
 
+    /// Currently edited script file, if any
+    private var editingScriptURL: URL?
+
     // Frame auto save name for app window frame restoration.
     private static let appWindowName = "boop.app.window"
     
@@ -62,7 +65,105 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @IBAction func executeLastScript(_ sender: Any) {
         popoverViewController.runScriptAgain()
     }
-    
+
+    @IBAction func undoLastScript(_ sender: Any) {
+        scriptManager.undoLastScript(editor: editor)
+    }
+
+    @IBAction func redoLastScript(_ sender: Any) {
+        scriptManager.redoLastScript(editor: editor)
+    }
+
+    @IBAction func clearScriptHistory(_ sender: Any) {
+        scriptManager.clearHistory()
+    }
+
+    @IBAction func newScript(_ sender: Any) {
+        editor.contentTextView.string = ScriptManager.defaultScriptTemplate
+        editingScriptURL = nil
+    }
+
+    @IBAction func openScript(_ sender: Any) {
+        let panel = NSOpenPanel()
+        panel.allowedFileTypes = ["js"]
+        if let url = try? ScriptManager.getBookmarkURL() {
+            panel.directoryURL = url
+        }
+        panel.begin { [weak self] result in
+            guard let self = self,
+                  result == .OK,
+                  let url = panel.url else { return }
+            self.editingScriptURL = url
+            self.editor.contentTextView.string = (try? String(contentsOf: url)) ?? ""
+        }
+    }
+
+    @IBAction func saveScript(_ sender: Any) {
+        if let url = editingScriptURL {
+            do {
+                try editor.contentTextView.string.write(to: url, atomically: true, encoding: .utf8)
+                scriptManager.reloadScripts()
+            } catch {
+                print("Failed to save script", error)
+            }
+        } else {
+            saveScriptAs(sender)
+        }
+    }
+
+    @IBAction func saveScriptAs(_ sender: Any) {
+        let panel = NSSavePanel()
+        panel.allowedFileTypes = ["js"]
+        panel.nameFieldStringValue = editingScriptURL?.lastPathComponent ?? "NewScript.js"
+        if let url = try? ScriptManager.getBookmarkURL() {
+            panel.directoryURL = url
+        }
+        panel.begin { [weak self] result in
+            guard let self = self,
+                  result == .OK,
+                  let url = panel.url else { return }
+            do {
+                try self.editor.contentTextView.string.write(to: url, atomically: true, encoding: .utf8)
+                self.editingScriptURL = url
+                self.scriptManager.reloadScripts()
+            } catch {
+                print("Failed to save script", error)
+            }
+        }
+    }
+
+    @IBAction func deleteScript(_ sender: Any) {
+        let panel = NSOpenPanel()
+        panel.allowedFileTypes = ["js"]
+        if let url = try? ScriptManager.getBookmarkURL() {
+            panel.directoryURL = url
+        }
+        panel.begin { [weak self] result in
+            guard let self = self,
+                  result == .OK,
+                  let url = panel.url else { return }
+            let alert = NSAlert()
+            alert.messageText = "Delete Script?"
+            alert.informativeText = url.lastPathComponent
+            alert.alertStyle = .warning
+            alert.addButton(withTitle: "Delete")
+            alert.addButton(withTitle: "Cancel")
+            alert.beginSheetModal(for: self.window) { response in
+                if response == .alertFirstButtonReturn {
+                    do {
+                        try FileManager.default.removeItem(at: url)
+                        if url == self.editingScriptURL {
+                            self.editingScriptURL = nil
+                        }
+                        self.scriptManager.reloadScripts()
+                    } catch {
+                        print("Failed to delete script", error)
+                    }
+                }
+            }
+        }
+    }
+
     @IBAction func reloadScripts(_ sender: Any) {
         scriptManager.reloadScripts()
     }
@@ -78,5 +179,38 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+}
+
+extension AppDelegate: NSMenuItemValidation {
+    func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
+        switch menuItem.identifier?.rawValue {
+        case "UNDO-SCRIPT-ITEM":
+            if let name = scriptManager.peekUndoScriptName() {
+                menuItem.title = "Undo \(name)"
+                return true
+            } else {
+                menuItem.title = "Undo Last Script"
+                return false
+            }
+        case "REDO-SCRIPT-ITEM":
+            if let name = scriptManager.peekRedoScriptName() {
+                menuItem.title = "Redo \(name)"
+                return true
+            } else {
+                menuItem.title = "Redo Last Script"
+                return false
+            }
+        case "CLEAR-HISTORY-ITEM":
+            return scriptManager.canClearHistory
+        case "SAVE-SCRIPT-ITEM":
+            return editingScriptURL != nil
+        case "DELETE-SCRIPT-ITEM":
+            return true
+        case "SAVE-AS-SCRIPT-ITEM":
+            return true
+        default:
+            return true
+        }
+    }
 }
 

--- a/Boop/Boop/Controllers/ScriptsTableViewController.swift
+++ b/Boop/Boop/Controllers/ScriptsTableViewController.swift
@@ -45,7 +45,13 @@ class ScriptsTableViewController: NSViewController, NSTableViewDelegate, NSTable
         }
         
         view.titleLabel.stringValue = script.name ?? "No Name 🤔"
-        view.subtitleLabel.stringValue = script.desc ?? "No Description 😢"
+
+        var subtitle = script.desc ?? "No Description 😢"
+        if let cats = script.categories, !cats.isEmpty {
+            let display = cats.map { $0.capitalized }.joined(separator: " · ")
+            subtitle += " \u2022 " + display
+        }
+        view.subtitleLabel.stringValue = subtitle
         
         view.imageView?.image = self.scriptIcon(identifier: script.icon)
         

--- a/Boop/Boop/System/Models/Script.swift
+++ b/Boop/Boop/System/Models/Script.swift
@@ -47,6 +47,7 @@ class Script: NSObject {
     var desc: String?
     var icon: String?
     var bias: Double?
+    var categories: [String]?
     
     weak var delegate: ScriptDelegate?
     
@@ -63,6 +64,16 @@ class Script: NSObject {
         self.desc = parameters["description"] as? String
         self.icon = (parameters["icon"] as? String)?.lowercased()
         self.bias = parameters["bias"] as? Double
+
+        if let cats = parameters["categories"] as? [String] {
+            let lower = cats.map { $0.lowercased() }
+            self.categories = Array(Set(lower)).sorted()
+        } else if let cats = parameters["categories"] as? String {
+            let lower = cats
+                .split(separator: ",")
+                .map { $0.trimmingCharacters(in: .whitespaces).lowercased() }
+            self.categories = Array(Set(lower)).sorted()
+        }
         
         
         
@@ -92,6 +103,7 @@ extension Script: Fuseable {
         return [
             FuseProperty(value: name, weight: 0.9),
             FuseProperty(value: tags, weight: 0.6),
+            FuseProperty(value: categories?.joined(separator: " "), weight: 0.4),
             FuseProperty(value: desc, weight: 0.2)
         ]
     }

--- a/Boop/Boop/scripts/ASCIIToHex.js
+++ b/Boop/Boop/scripts/ASCIIToHex.js
@@ -5,8 +5,9 @@
 		"description":"Converts ASCII characters to hexadecimal codes.",
 		"author":"aWZHY0yQH81uOYvH",
 		"icon":"metamorphose",
-		"tags":"ascii,hex,convert"
-	}
+                "tags":"ascii,hex,convert",
+                "categories":["convert","numbers"]
+        }
 **/
 
 function main(state) {

--- a/Boop/Boop/scripts/AddSlashes.js
+++ b/Boop/Boop/scripts/AddSlashes.js
@@ -5,8 +5,9 @@
 		"description":"Escapes your text.",
 		"author":"Ivan",
 		"icon":"quote",
-		"tags":"add,slashes,escape"
-	}
+                "tags":"add,slashes,escape",
+                "categories":["text","convert"]
+        }
 **/
 
 function main(input) {

--- a/Boop/Boop/scripts/Base64Encode.js
+++ b/Boop/Boop/scripts/Base64Encode.js
@@ -5,8 +5,9 @@
 		"description":"Encodes your text to Base64",
 		"author":"See Source",
 		"icon":"metamorphose",
-		"tags":"base64,atob,encode"
-	}
+                "tags":"base64,atob,encode",
+                "categories":["convert","text"]
+        }
 **/
 
 const { encode } = require('@boop/base64')

--- a/Boop/Boop/scripts/BinaryToDecimal.js
+++ b/Boop/Boop/scripts/BinaryToDecimal.js
@@ -5,9 +5,10 @@
    "description": "Converts binary values to decimal.",
    "author": "Maurice",
    "icon": "metamorphose",
-   "tags": "decimal,binary,dec,bin"
+   "tags": "decimal,binary,dec,bin",
+   "categories": ["convert","numbers"]
  }
- **/
+**/
 
 function main(state) {
   var text = state.text;

--- a/Boop/Boop/scripts/CSVtoJSON.js
+++ b/Boop/Boop/scripts/CSVtoJSON.js
@@ -5,9 +5,10 @@
 		"description":"Converts comma-separated tables to JSON.",
 		"author":"Ivan",
 		"icon":"table",
-		"tags":"table,convert",
-        	"bias": -0.2
-	}
+                "tags":"table,convert",
+                "categories":["convert","text"],
+                "bias": -0.2
+        }
 **/
 const Papa = require('@boop/papaparse.js');
 

--- a/Boop/Boop/scripts/CountCharacters.js
+++ b/Boop/Boop/scripts/CountCharacters.js
@@ -5,8 +5,9 @@
 		"description":"Get the length of your text",
 		"author":"Ivan",
 		"icon":"counter",
-		"tags":"count,length,size,character"
-	}
+                "tags":"count,length,size,character",
+                "categories":["analysis","text"]
+        }
 **/
 
 

--- a/Boop/Boop/scripts/CountWords.js
+++ b/Boop/Boop/scripts/CountWords.js
@@ -5,7 +5,8 @@
     "description":"Get the word count of your text",
     "author":"Daniel Stone",
     "icon":"counter",
-    "tags":"count,length,size,words"
+    "tags":"count,length,size,words",
+    "categories":["analysis","text"]
   }
 **/
 function main(input) {

--- a/Boop/Documentation/CustomScripts.md
+++ b/Boop/Documentation/CustomScripts.md
@@ -31,6 +31,9 @@ Each script starts with a declarative JSON document, describing the contents of 
 * `name`, `description` and `author` are exactly what you think they are.
 * `icon` is a visual representation of your scripts' actions. You can see available icons in `Boop/Assets.xcassets/Icons/`. On macOS 11 and above you can also use [SF Symbols](https://developer.apple.com/sf-symbols/). If you can't find what you like, feel free to create an issue and we'll make it work!
 * `tags` are used by the fuzzy-search algorythm to filter and sort results.
+* `categories` is an optional array or comma-separated string allowing scripts
+  to belong to multiple groups, such as `"text"` or `"convert"`. Users can
+  filter the picker by category with `cat:name`, e.g. `cat:text`.
 
 An optional property, `bias`, can also be added to help Boop prioritize your scripts. A positive value will move your script higher in the results, a negative value will push it further down. The bias property is a number:
 

--- a/Boop/Documentation/Readme.md
+++ b/Boop/Documentation/Readme.md
@@ -23,9 +23,14 @@ From the script picker, start typing to search for a script. You can then press 
 
 You can run the last script again by pressing `⇧⌘B` or from the option in the scripts menu.
 
-To start over, you can clear the editor by pressing `⌘N`. 
+To start over, you can clear the editor by pressing `⌘N`.
+
+If a script messed up your text, you can undo it with `⌥⌘Z`. To redo an undone script, use `⇧⌥⌘Z`.
+You can clear the script history with `⌥⌘K` and change how many undo steps are kept in the Scripts preferences.
 
 If you are developing scripts, you can reload all the script by pressing `⇧⌘R` or  from the script menu as well.
+
+You can also manage scripts without leaving the app. Choose **Scripts → New Script** to insert a template, **Open Script…** to load an existing file, then **Save Script** or **Save Script As…** to store your changes. Use **Delete Script…** to remove a script you no longer need. The script list reloads automatically after saving or deleting.
 
 ## Questions
 

--- a/Boop/UI/Base.lproj/MainMenu.xib
+++ b/Boop/UI/Base.lproj/MainMenu.xib
@@ -196,6 +196,24 @@
                                     <action selector="redo:" target="-1" id="oIA-Rs-6OD"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Undo Last Script" keyEquivalent="z" id="UNDO-SCRIPT-ITEM">
+                                <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                <connections>
+                                    <action selector="undoLastScript:" target="-1" id="UNDO-SCRIPT-ACT"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Redo Last Script" keyEquivalent="Z" id="REDO-SCRIPT-ITEM">
+                                <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES" shift="YES"/>
+                                <connections>
+                                    <action selector="redoLastScript:" target="-1" id="REDO-SCRIPT-ACT"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Clear Script History" keyEquivalent="k" id="CLEAR-HISTORY-ITEM">
+                                <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                <connections>
+                                    <action selector="clearScriptHistory:" target="-1" id="CLEAR-HISTORY-ACT"/>
+                                </connections>
+                            </menuItem>
                             <menuItem isSeparatorItem="YES" id="WRV-NI-Exz"/>
                             <menuItem title="Cut" keyEquivalent="x" id="uRl-iY-unG">
                                 <connections>
@@ -446,6 +464,36 @@ Gw
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="Zfh-13-od8"/>
+                            <menuItem title="Open Script…" keyEquivalent="o" id="OPEN-SCRIPT-ITEM">
+                                <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                <connections>
+                                    <action selector="openScript:" target="Voe-Tx-rLC" id="OPEN-SCRIPT-ACT"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="New Script" keyEquivalent="n" id="NEW-SCRIPT-ITEM">
+                                <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                <connections>
+                                    <action selector="newScript:" target="Voe-Tx-rLC" id="NEW-SCRIPT-ACT"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Save Script" keyEquivalent="s" id="SAVE-SCRIPT-ITEM">
+                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
+                                <connections>
+                                    <action selector="saveScript:" target="Voe-Tx-rLC" id="SAVE-SCRIPT-ACT"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Save Script As…" keyEquivalent="s" id="SAVE-AS-SCRIPT-ITEM">
+                                <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                <connections>
+                                    <action selector="saveScriptAs:" target="Voe-Tx-rLC" id="SAVE-AS-SCRIPT-ACT"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Delete Script…" id="DELETE-SCRIPT-ITEM">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="deleteScript:" target="Voe-Tx-rLC" id="DELETE-SCRIPT-ACT"/>
+                                </connections>
+                            </menuItem>
                             <menuItem title="Reload Scripts" keyEquivalent="R" id="AVC-ge-jRm">
                                 <connections>
                                     <action selector="reloadScripts:" target="Voe-Tx-rLC" id="Rmu-D9-Xm5"/>

--- a/Enhancements.md
+++ b/Enhancements.md
@@ -1,0 +1,44 @@
+# Suggested Improvements for Boop
+
+This document collects ideas for making Boop better. Items are grouped by how easy they might be to implement and their potential impact.
+
+### Categories
+Every enhancement is labeled with one or more categories so that related ideas are easy to find. The current labels are:
+
+- **UI** – changes to Boop's interface or user interactions
+- **Editor** – editing or text manipulation features
+- **Script Management** – improvements to managing or running scripts
+- **Developer Tools** – features that help script authors
+- **Community** – sharing or collaborative features
+
+## Quick Wins
+These are relatively small changes that should have a noticeable positive effect:
+
+- **Favorites in Script Picker** _(UI, Script Management)_: Mark scripts as favorites so they appear at the top of search results.
+- **Categorized Script List** _(UI, Script Management)_: Basic grouping of scripts by category in the picker. Each script can belong to multiple categories.
+- **Shortcut Customization** _(UI)_: Allow users to assign hotkeys to frequently used scripts.
+- **One‑Click Script Reload** _(Script Management)_: Add a button or menu option to reload scripts without a shortcut.
+- **Improved Error Messages** _(Developer Tools)_: Include the script name and line number when a script fails.
+- **History Stack** _(Editor)_ ✔: Revert scripts with `Undo Last Script` (`⌥⌘Z`).
+- **Clearable History** _(Editor)_ ✔: Option to clear script history and set the
+  maximum number of undo steps.
+- **Script Template Generator** _(Developer Tools)_ ✔: Scaffold a new script from a built-in template.
+- **In‑App Script Editing** _(Script Management)_ ✔: Create, update, and delete scripts right inside Boop.
+
+## Medium Effort
+Require a bit more work but still relatively contained:
+
+- **Automatic Script Updates** _(Script Management)_: Check an official repository for script updates and install them on demand.
+- **Theme Import/Export** _(UI)_: Let users share color themes via files.
+- **Preview Before Apply** _(UI, Editor)_: Show the result of a script in a separate pane before replacing the text.
+- **Inline Documentation** _(UI, Developer Tools)_: Display a short explanation or link to docs when hovering over a script in the picker.
+
+## Bigger Projects
+These would have high impact but may take longer to design and implement:
+
+- **Plugin System for Extensions** _(Developer Tools, Editor)_: Allow third‑party Swift/JS plugins to extend the editor beyond scripts.
+- **Collaborative Script Library** _(Community, Script Management)_: Integrate directly with a Git repository to share and rate community scripts.
+- **Multi Cursor Editing** _(Editor)_ *(already in progress)*: Support simultaneous cursors for faster editing.
+- **Split Script Repository** _(Script Management, Community)_ *(planned)*: Move built‑in scripts to a separate repo for easier contributions.
+
+This list can serve as a starting point for prioritizing future work.


### PR DESCRIPTION
## Summary
- make undo history depth configurable and track script names
- add menu option to clear script history
- update menu items dynamically for available undo/redo actions
- document undo history options in README
- note clearable history enhancement
- allow scripts to be edited and deleted from Boop

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686617992e88832cb8ed72035b1b0a87