### PR TITLE
Enable more script interpreters

### DIFF
--- a/Boop/Boop.xcodeproj/project.pbxproj
+++ b/Boop/Boop.xcodeproj/project.pbxproj
@@ -79,7 +79,8 @@
 		2CA245DC224822EA00586DFD /* ScriptTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA245DB224822EA00586DFD /* ScriptTableView.swift */; };
 		2CC211C3236E3141007CECEE /* PreferencesTabViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC211C2236E3141007CECEE /* PreferencesTabViewController.swift */; };
 		2CC211C5236FB5C1007CECEE /* ScriptsSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC211C4236FB5C1007CECEE /* ScriptsSettingsViewController.swift */; };
-		2CEC93FA249C2D600080B9B8 /* ThemeSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CEC93F9249C2D600080B9B8 /* ThemeSettingsViewController.swift */; };
+               2CEC93FA249C2D600080B9B8 /* ThemeSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CEC93F9249C2D600080B9B8 /* ThemeSettingsViewController.swift */; };
+               AA0AA002FFFFFFF000000001 /* RuntimeSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0AA001FFFFFFF000000001 /* RuntimeSettingsViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -157,7 +158,8 @@
 		2CB9D7F024319BAC00135424 /* Fuse.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Fuse.framework; path = ../../../Carthage/Build/Mac/Fuse.framework; sourceTree = "<group>"; };
 		2CC211C2236E3141007CECEE /* PreferencesTabViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesTabViewController.swift; sourceTree = "<group>"; };
 		2CC211C4236FB5C1007CECEE /* ScriptsSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptsSettingsViewController.swift; sourceTree = "<group>"; };
-		2CEC93F9249C2D600080B9B8 /* ThemeSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeSettingsViewController.swift; sourceTree = "<group>"; };
+               2CEC93F9249C2D600080B9B8 /* ThemeSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeSettingsViewController.swift; sourceTree = "<group>"; };
+               AA0AA001FFFFFFF000000001 /* RuntimeSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuntimeSettingsViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -322,16 +324,17 @@
 			path = Models;
 			sourceTree = "<group>";
 		};
-		2CC211C1236E3125007CECEE /* Preferences */ = {
-			isa = PBXGroup;
-			children = (
-				2CC211C2236E3141007CECEE /* PreferencesTabViewController.swift */,
-				2CC211C4236FB5C1007CECEE /* ScriptsSettingsViewController.swift */,
-				2CEC93F9249C2D600080B9B8 /* ThemeSettingsViewController.swift */,
-			);
-			path = Preferences;
-			sourceTree = "<group>";
-		};
+               2CC211C1236E3125007CECEE /* Preferences */ = {
+                        isa = PBXGroup;
+                        children = (
+                                2CC211C2236E3141007CECEE /* PreferencesTabViewController.swift */,
+                                2CC211C4236FB5C1007CECEE /* ScriptsSettingsViewController.swift */,
+                                2CEC93F9249C2D600080B9B8 /* ThemeSettingsViewController.swift */,
+                                AA0AA001FFFFFFF000000001 /* RuntimeSettingsViewController.swift */,
+                        );
+                        path = Preferences;
+                        sourceTree = "<group>";
+                };
 		53D77B44249A4019002A2F02 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -555,9 +558,10 @@
 				2C60A54C24871273006496BA /* MainViewController.swift in Sources */,
 				2C60A54D24871273006496BA /* StatusView.swift in Sources */,
 				2C60A54E24871273006496BA /* UpdateTextField.swift in Sources */,
-				2C60A54F24871273006496BA /* PreferencesTabViewController.swift in Sources */,
-				2C60A55024871273006496BA /* ScriptsTableViewController.swift in Sources */,
-			);
+                               2C60A54F24871273006496BA /* PreferencesTabViewController.swift in Sources */,
+                               2C60A55024871273006496BA /* ScriptsTableViewController.swift in Sources */,
+                                AA0AA002FFFFFFF000000001 /* RuntimeSettingsViewController.swift in Sources */,
+                        );
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */

--- a/Boop/Boop/Controllers/Preferences/RuntimeSettingsViewController.swift
+++ b/Boop/Boop/Controllers/Preferences/RuntimeSettingsViewController.swift
@@ -1,0 +1,75 @@
+import Cocoa
+
+class RuntimeSettingsViewController: NSViewController {
+    let interpreters: [ScriptInterpreter] = [.python, .ruby, .perl, .lua, .node]
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        let stack = NSStackView()
+        stack.orientation = .vertical
+        stack.spacing = 10
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 30),
+            stack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -30),
+            stack.topAnchor.constraint(equalTo: view.topAnchor, constant: 20)
+        ])
+        for inter in interpreters {
+            let row = NSStackView()
+            row.orientation = .horizontal
+            row.spacing = 10
+            let check = NSButton(checkboxWithTitle: inter.displayName, target: self, action: #selector(toggleEnabled(_:)))
+            check.identifier = NSUserInterfaceItemIdentifier(inter.enableKey)
+            check.state = inter.isEnabled ? .on : .off
+            let field = NSTextField(string: UserDefaults.standard.string(forKey: inter.pathKey) ?? inter.command(bundle: Bundle.main)?[0] ?? "")
+            field.identifier = NSUserInterfaceItemIdentifier(inter.pathKey)
+            field.target = self
+            field.action = #selector(pathChanged(_:))
+            let keywordField = NSTextField(string: inter.requireKeyword)
+            keywordField.identifier = NSUserInterfaceItemIdentifier(inter.requireKey)
+            keywordField.target = self
+            keywordField.action = #selector(runtimeKeywordChanged(_:))
+            row.addArrangedSubview(check)
+            row.addArrangedSubview(field)
+            row.addArrangedSubview(keywordField)
+            stack.addArrangedSubview(row)
+        }
+
+        let reqRow = NSStackView()
+        reqRow.orientation = .horizontal
+        reqRow.spacing = 10
+        let label = NSTextField(labelWithString: "Default keyword")
+        let reqField = NSTextField(string: UserDefaults.standard.string(forKey: "runtime.require.keyword") ?? "")
+        reqField.identifier = NSUserInterfaceItemIdentifier("runtime.require.keyword")
+        reqField.target = self
+        reqField.action = #selector(defaultKeywordChanged(_:))
+        reqRow.addArrangedSubview(label)
+        reqRow.addArrangedSubview(reqField)
+        stack.addArrangedSubview(reqRow)
+    }
+
+    override func viewWillAppear() {
+        super.viewWillAppear()
+        preferredContentSize = view.fittingSize
+    }
+
+    @objc func toggleEnabled(_ sender: NSButton) {
+        guard let key = sender.identifier?.rawValue else { return }
+        UserDefaults.standard.set(sender.state == .on, forKey: key)
+    }
+
+    @objc func pathChanged(_ sender: NSTextField) {
+        guard let key = sender.identifier?.rawValue else { return }
+        UserDefaults.standard.set(sender.stringValue, forKey: key)
+    }
+
+    @objc func runtimeKeywordChanged(_ sender: NSTextField) {
+        guard let key = sender.identifier?.rawValue else { return }
+        UserDefaults.standard.set(sender.stringValue, forKey: key)
+    }
+
+    @objc func defaultKeywordChanged(_ sender: NSTextField) {
+        UserDefaults.standard.set(sender.stringValue, forKey: "runtime.require.keyword")
+    }
+}

--- a/Boop/Boop/System/Models/Script.swift
+++ b/Boop/Boop/System/Models/Script.swift
@@ -10,17 +10,175 @@ import Foundation
 import JavaScriptCore
 import Fuse
 
+enum ScriptPermission: String {
+    case network
+    case llm
+}
+
+enum ScriptInterpreter {
+    case javaScriptCore
+    case python
+    case ruby
+    case perl
+    case lua
+    case node
+
+    init(fileExtension ext: String) {
+        switch ext.lowercased() {
+        case "py": self = .python
+        case "rb": self = .ruby
+        case "pl": self = .perl
+        case "lua": self = .lua
+        case "njs": self = .node
+        default: self = .javaScriptCore
+        }
+    }
+
+    func command(bundle: Bundle) -> [String]? {
+        guard isEnabled else { return nil }
+        switch self {
+        case .javaScriptCore:
+            return nil
+        case .python:
+            guard let bridge = bundle.path(forResource: "bridge", ofType: "py", inDirectory: "bridges/python") else { return nil }
+            let path = UserDefaults.standard.string(forKey: pathKey) ?? "python3"
+            return [path, bridge]
+        case .ruby:
+            guard let bridge = bundle.path(forResource: "bridge", ofType: "rb", inDirectory: "bridges/ruby") else { return nil }
+            let path = UserDefaults.standard.string(forKey: pathKey) ?? "ruby"
+            return [path, bridge]
+        case .perl:
+            guard let bridge = bundle.path(forResource: "bridge", ofType: "pl", inDirectory: "bridges/perl") else { return nil }
+            let path = UserDefaults.standard.string(forKey: pathKey) ?? "perl"
+            return [path, bridge]
+        case .lua:
+            guard let bridge = bundle.path(forResource: "bridge", ofType: "lua", inDirectory: "bridges/lua") else { return nil }
+            let path = UserDefaults.standard.string(forKey: pathKey) ?? "lua"
+            return [path, bridge]
+        case .node:
+            guard let bridge = bundle.path(forResource: "bridge", ofType: "js", inDirectory: "bridges/node") else { return nil }
+            let path = UserDefaults.standard.string(forKey: pathKey) ?? "node"
+            return [path, bridge]
+        }
+    }
+
+    static var supportedExtensions: [String] {
+        return ["js", "py", "rb", "pl", "lua", "njs"]
+    }
+
+    var enableKey: String {
+        switch self {
+        case .javaScriptCore: return "runtime.js.enabled"
+        case .python: return "runtime.py.enabled"
+        case .ruby: return "runtime.rb.enabled"
+        case .perl: return "runtime.pl.enabled"
+        case .lua: return "runtime.lua.enabled"
+        case .node: return "runtime.node.enabled"
+        }
+    }
+
+    var pathKey: String {
+        switch self {
+        case .javaScriptCore: return "runtime.js.path"
+        case .python: return "runtime.py.path"
+        case .ruby: return "runtime.rb.path"
+        case .perl: return "runtime.pl.path"
+        case .lua: return "runtime.lua.path"
+        case .node: return "runtime.node.path"
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .javaScriptCore: return "JavaScript"
+        case .python: return "Python"
+        case .ruby: return "Ruby"
+        case .perl: return "Perl"
+        case .lua: return "Lua"
+        case .node: return "Node.js"
+        }
+    }
+
+    var shortName: String {
+        switch self {
+        case .javaScriptCore: return "JS"
+        case .python: return "PY"
+        case .ruby: return "RB"
+        case .perl: return "PL"
+        case .lua: return "LUA"
+        case .node: return "NODE"
+        }
+    }
+
+    var isEnabled: Bool {
+        if self == .javaScriptCore { return true }
+        return UserDefaults.standard.object(forKey: enableKey) as? Bool ?? true
+    }
+
+    var moduleExtension: String {
+        switch self {
+        case .javaScriptCore: return ".js"
+        case .python: return ".py"
+        case .ruby: return ".rb"
+        case .perl: return ".pl"
+        case .lua: return ".lua"
+        case .node: return ".njs"
+        }
+    }
+
+    var defaultRequireKeyword: String {
+        switch self {
+        case .javaScriptCore, .node:
+            return "require"
+        default:
+            return "boop_require"
+        }
+    }
+
+    static var globalRequireKeyword: String? {
+        UserDefaults.standard.string(forKey: "runtime.require.keyword")
+    }
+
+    var requireKey: String {
+        switch self {
+        case .javaScriptCore: return "runtime.js.require.keyword"
+        case .python: return "runtime.py.require.keyword"
+        case .ruby: return "runtime.rb.require.keyword"
+        case .perl: return "runtime.pl.require.keyword"
+        case .lua: return "runtime.lua.require.keyword"
+        case .node: return "runtime.node.require.keyword"
+        }
+    }
+
+    var requireKeyword: String {
+        if let per = UserDefaults.standard.string(forKey: requireKey) {
+            return per
+        }
+        if let global = ScriptInterpreter.globalRequireKeyword {
+            return global
+        }
+        return defaultRequireKeyword
+    }
+
+    static func isSupported(_ ext: String) -> Bool {
+        supportedExtensions.contains(ext.lowercased())
+    }
+}
+
 class Script: NSObject {
-    
+
     var isBuiltInt: Bool
     var url: URL
     var scriptCode: String
+    var interpreter: ScriptInterpreter
+    var permissions: Set<ScriptPermission>
     
     
-    lazy var context: JSContext = { [unowned self] in
+    lazy var context: JSContext? = { [unowned self] in
+        guard interpreter == .javaScriptCore else { return nil }
         let context: JSContext = JSContext()
         context.name = self.name ?? "Unknown Script"
-        
+
         context.exceptionHandler = { [unowned self] context, exception in
             let message = "[\(self.name ?? "Unknown Script")] Error: \(exception?.toString() ?? "Unknown Error") "
             print(message)
@@ -28,16 +186,16 @@ class Script: NSObject {
         }
 
         self.setupRequire(context: context)
-        
+
         context.setObject(ScriptExecution.self, forKeyedSubscript: "ScriptExecution" as NSString)
-        
+
         context.evaluateScript(self.scriptCode, withSourceURL: url)
-        
+
         return context
     }()
-    
-    lazy var main: JSValue = {
-        return context.objectForKeyedSubscript("main")
+
+    lazy var main: JSValue? = {
+        context?.objectForKeyedSubscript("main")
     }()
     
     var info:[String: Any]
@@ -51,13 +209,22 @@ class Script: NSObject {
     
     weak var delegate: ScriptDelegate?
     
-    init(url: URL, script:String, parameters: [String: Any], builtIn: Bool, delegate: ScriptDelegate? = nil) {
+    init(url: URL, script:String, parameters: [String: Any], builtIn: Bool, interpreter: ScriptInterpreter, delegate: ScriptDelegate? = nil) {
         
         
         self.scriptCode = script
         self.info = parameters
         self.url = url
         self.isBuiltInt = builtIn
+        self.interpreter = interpreter
+        if let perms = parameters["permissions"] as? [String] {
+            self.permissions = Set(perms.compactMap { ScriptPermission(rawValue: $0.lowercased()) })
+        } else if let perm = parameters["permissions"] as? String {
+            let split = perm.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces).lowercased() }
+            self.permissions = Set(split.compactMap { ScriptPermission(rawValue: $0) })
+        } else {
+            self.permissions = []
+        }
         
         self.name = parameters["name"] as? String
         self.tags = parameters["tags"] as? String
@@ -90,9 +257,70 @@ class Script: NSObject {
     func onScriptInfo(message: String) {
         self.delegate?.onScriptInfo(message: message)
     }
-    
+
     func run(with execution: ScriptExecution) {
-        main.call(withArguments: [execution])
+        switch interpreter {
+        case .javaScriptCore:
+            main?.call(withArguments: [execution])
+        case .python, .ruby, .perl, .lua, .node:
+            runExternal(with: execution)
+        }
+    }
+
+    private func runExternal(with execution: ScriptExecution) {
+        guard let command = interpreter.command(bundle: Bundle.main) else { return }
+
+        var env = ProcessInfo.processInfo.environment
+        var state: [String: Any] = [
+            "text": execution.text ?? "",
+            "fullText": execution.fullText ?? "",
+            "selection": execution.selection ?? "",
+            "network": permissions.contains(.network)
+        ]
+        if let data = try? JSONSerialization.data(withJSONObject: state, options: []) {
+            env["BOOP_STATE"] = String(data: data, encoding: .utf8)
+        }
+
+        env["BOOP_MODULE_EXT"] = interpreter.moduleExtension
+        env["BOOP_SCRIPT_DIR"] = url.deletingLastPathComponent().path
+        if let lib = Bundle.main.resourceURL?.appendingPathComponent("scripts/lib").path {
+            env["BOOP_LIB_DIR"] = lib
+        }
+        env["BOOP_REQUIRE_NAME"] = interpreter.requireKeyword
+
+        let process = Process()
+        process.launchPath = command.first
+        process.arguments = Array(command.dropFirst()) + [url.path]
+        process.environment = env
+
+        let outputPipe = Pipe()
+        process.standardOutput = outputPipe
+
+        process.launch()
+        process.waitUntilExit()
+
+        let data = outputPipe.fileHandleForReading.readDataToEndOfFile()
+        outputPipe.fileHandleForReading.closeFile()
+
+        guard
+            let dict = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
+        else { return }
+
+        if let text = dict["text"] as? String { execution.text = text }
+        if let full = dict["fullText"] as? String { execution.fullText = full }
+        if let sel = dict["selection"] as? String { execution.selection = sel }
+        if let inserts = dict["inserts"] as? [String] {
+            inserts.forEach { execution.insert($0) }
+        }
+        if let messages = dict["messages"] as? [[String: String]] {
+            for msg in messages {
+                if msg["type"] == "error", let m = msg["message"] {
+                    execution.postError(m)
+                } else if msg["type"] == "info", let m = msg["message"] {
+                    execution.postInfo(m)
+                }
+            }
+        }
     }
     
 }

--- a/Boop/Boop/bridges/lua/bridge.lua
+++ b/Boop/Boop/bridges/lua/bridge.lua
@@ -1,0 +1,79 @@
+#!/usr/bin/env lua
+local state_json = os.getenv('BOOP_STATE') or '{}'
+local state = {}
+local ok, res = pcall(function() return assert(load('return '..state_json))() end)
+if ok then state = res else state = {} end
+
+local MODULE_EXT = os.getenv('BOOP_MODULE_EXT') or '.lua'
+local SCRIPT_DIR = os.getenv('BOOP_SCRIPT_DIR') or ''
+local LIB_DIR = os.getenv('BOOP_LIB_DIR') or ''
+local REQUIRE_NAME = os.getenv('BOOP_REQUIRE_NAME') or 'boop_require'
+
+local loaded = {}
+local function _boop_require(path)
+  local p = path
+  if p:sub(-#MODULE_EXT) ~= MODULE_EXT then p = p .. MODULE_EXT end
+  local file
+  if p:sub(1,6) == '@boop/' then
+    file = LIB_DIR .. '/' .. p:sub(7)
+  else
+    file = SCRIPT_DIR .. '/' .. p
+  end
+  if loaded[file] then return loaded[file] end
+  local f = loadfile(file)
+  if not f then return nil end
+  local mod = f() or {}
+  loaded[file] = mod
+  return mod
+end
+
+_G[REQUIRE_NAME] = _boop_require
+if REQUIRE_NAME ~= 'boop_require' then
+  _G['boop_require'] = _boop_require
+end
+
+local State = {}
+State.__index = State
+function State:new(data)
+  local obj = setmetatable({}, self)
+  obj.text = data.text
+  obj.fullText = data.fullText
+  obj.selection = data.selection
+  obj.network = data.network
+  obj.inserts = {}
+  obj.messages = {}
+  return obj
+end
+function State:post_info(msg) table.insert(self.messages, {type='info', message=msg}) end
+function State:post_error(msg) table.insert(self.messages, {type='error', message=msg}) end
+function State:insert(val) table.insert(self.inserts, val) end
+function State:fetch(url, method, body)
+  if not self.network then self:post_error('Network permission required'); return nil end
+  local cmd = 'curl -sL '
+  if method and method ~= 'GET' then cmd = cmd .. '-X '..method..' ' end
+  if body then cmd = cmd .. '--data '..string.format('%q', body)..' ' end
+  cmd = cmd .. url
+  local f = io.popen(cmd, 'r')
+  local data = f:read('*a')
+  local ok2 = f:close()
+  if ok2 then return data else self:post_error('Failed to fetch'); return nil end
+end
+local function escape(s) return s:gsub('\\','\\\\'):gsub('"','\\"'):gsub('\n','\\n') end
+function State:to_json()
+  local parts = {
+    '"text":"'..escape(self.text or '')..'"',
+    '"fullText":"'..escape(self.fullText or '')..'"',
+    '"selection":"'..escape(self.selection or '')..'"',
+    '"inserts":['..table.concat((function()
+      local arr={} for i,v in ipairs(self.inserts) do arr[i]='"'..escape(v)..'"' end return arr end)(),',')..']',
+    '"messages":['..table.concat((function()
+      local arr={} for i,v in ipairs(self.messages) do arr[i]='{"type":"'..escape(v.type)..'","message":"'..escape(v.message)..'"}' end return arr end)(),',')..']'
+  }
+  return '{'..table.concat(parts, ',')..'}'
+end
+
+local script = arg[1]
+local stateObj = State:new(state)
+local user = assert(loadfile(script))
+if user then user()(stateObj) end
+print(stateObj:to_json())

--- a/Boop/Boop/bridges/node/bridge.js
+++ b/Boop/Boop/bridges/node/bridge.js
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+const {execFileSync} = require('child_process');
+const fs = require('fs');
+const Module = require('module');
+const path = require('path');
+
+const state = JSON.parse(process.env.BOOP_STATE || '{}');
+const MODULE_EXT = process.env.BOOP_MODULE_EXT || '.njs';
+const SCRIPT_DIR = process.env.BOOP_SCRIPT_DIR || '';
+const LIB_DIR = process.env.BOOP_LIB_DIR || '';
+
+require.extensions['.njs'] = require.extensions['.js'];
+
+const originalRequire = Module.prototype.require;
+Module.prototype.require = function(name) {
+  let target = name;
+  if(!target.endsWith(MODULE_EXT)) target += MODULE_EXT;
+  let file;
+  if(target.startsWith('@boop/')) {
+    file = path.join(LIB_DIR, target.slice(6));
+  } else {
+    file = path.join(SCRIPT_DIR, target);
+  }
+  if(fs.existsSync(file)) return originalRequire.call(this, file);
+  return originalRequire.call(this, name);
+};
+
+class State {
+  constructor(data){
+    this.text = data.text;
+    this.fullText = data.fullText;
+    this.selection = data.selection;
+    this.network = data.network;
+    this.inserts = [];
+    this.messages = [];
+  }
+  post_info(msg){ this.messages.push({type:'info', message: msg}); }
+  post_error(msg){ this.messages.push({type:'error', message: msg}); }
+  insert(val){ this.inserts.push(val); }
+  fetch(url, method, body){
+    if(!this.network){ this.post_error('Network permission required'); return null; }
+    try{
+      const args = ['-sL'];
+      if(method && method !== 'GET') args.push('-X', method);
+      if(body) args.push('--data', body);
+      args.push(url);
+      return execFileSync('curl', args, {encoding: 'utf8'});
+    }catch(e){
+      this.post_error('Failed to fetch');
+      return null;
+    }
+  }
+}
+
+const scriptPath = process.argv[2];
+const stateObj = new State(state);
+const user = require(path.resolve(scriptPath));
+if(typeof user.main === 'function'){
+  const res = user.main(stateObj);
+  if(res && typeof res.then === 'function') {
+    res.then(()=>finish()).catch(()=>finish());
+  } else {
+    finish();
+  }
+} else {
+  finish();
+}
+
+function finish(){
+  const output = {
+    text: stateObj.text,
+    fullText: stateObj.fullText,
+    selection: stateObj.selection,
+    inserts: stateObj.inserts,
+    messages: stateObj.messages
+  };
+  console.log(JSON.stringify(output));
+}

--- a/Boop/Boop/bridges/perl/bridge.pl
+++ b/Boop/Boop/bridges/perl/bridge.pl
@@ -1,0 +1,78 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use JSON::PP;
+use Encode;
+use File::Spec;
+
+my $MODULE_EXT = $ENV{BOOP_MODULE_EXT} || '.pl';
+my $SCRIPT_DIR = $ENV{BOOP_SCRIPT_DIR} || '';
+my $LIB_DIR = $ENV{BOOP_LIB_DIR} || '';
+my $REQUIRE_NAME = $ENV{BOOP_REQUIRE_NAME} || 'boop_require';
+
+my $state_json = $ENV{BOOP_STATE} || '{}';
+my $data = decode_json($state_json);
+
+package State;
+sub new {
+    my ($class, $d) = @_;
+    my $self = {
+        text => $d->{text},
+        fullText => $d->{fullText},
+        selection => $d->{selection},
+        network => $d->{network},
+        inserts => [],
+        messages => []
+    };
+    bless $self, $class;
+    return $self;
+}
+sub post_info { my ($s,$m)=@_; push @{$s->{messages}}, {type=>'info', message=>$m}; }
+sub post_error { my ($s,$m)=@_; push @{$s->{messages}}, {type=>'error', message=>$m}; }
+sub insert { my ($s,$v)=@_; push @{$s->{inserts}}, $v; }
+sub fetch {
+    my ($s,$url,$method,$body)=@_;
+    return undef unless $s->{network};
+    my @cmd = ('curl','-sL');
+    push @cmd,('-X',$method) if defined $method && $method ne 'GET';
+    push @cmd,('--data',$body) if defined $body;
+    push @cmd,$url;
+    my $out = `@cmd`;
+    if ($?==0){ return Encode::decode('UTF-8',$out); }
+    else { $s->post_error('Failed to fetch'); return undef; }
+}
+sub to_hash { my $s=shift; return { text=>$s->{text}, fullText=>$s->{fullText}, selection=>$s->{selection}, inserts=>$s->{inserts}, messages=>$s->{messages} }; }
+1;
+
+package main;
+
+sub _boop_require {
+    my ($path) = @_;
+    my $p = $path;
+    $p .= $MODULE_EXT unless $p =~ /\Q$MODULE_EXT\E$/;
+    my $full;
+    if ($p =~ /^\@boop\//) {
+        $full = File::Spec->catfile($LIB_DIR, substr($p,6));
+    } else {
+        $full = File::Spec->catfile($SCRIPT_DIR, $p);
+    }
+    if (-e $full) {
+        do $full;
+    } else {
+        CORE::require($path);
+    }
+}
+no strict 'refs';
+*{$REQUIRE_NAME} = \&_boop_require;
+if ($REQUIRE_NAME ne 'boop_require') {
+    *boop_require = \&_boop_require;
+}
+use strict 'refs';
+my $script = shift @ARGV;
+my $state = State->new($data);
+no strict 'refs';
+&{$REQUIRE_NAME}("./$script");
+use strict 'refs';
+State::post_error($state,'No main function') unless defined &main;
+main($state) if defined &main;
+print encode_json($state->to_hash);

--- a/Boop/Boop/bridges/python/bridge.py
+++ b/Boop/Boop/bridges/python/bridge.py
@@ -1,0 +1,79 @@
+import importlib.util
+import json
+import os
+import sys
+import urllib.request
+
+state = json.loads(os.environ.get('BOOP_STATE', '{}'))
+module_ext = os.environ.get('BOOP_MODULE_EXT', '.py')
+script_dir = os.environ.get('BOOP_SCRIPT_DIR', '')
+lib_dir = os.environ.get('BOOP_LIB_DIR', '')
+require_name = os.environ.get('BOOP_REQUIRE_NAME', 'boop_require')
+
+_loaded_modules = {}
+
+def _boop_require(path):
+    if not path.endswith(module_ext):
+        path += module_ext
+    if path.startswith('@boop/'):
+        mod_path = os.path.join(lib_dir, path[6:])
+    else:
+        mod_path = os.path.join(script_dir, path)
+    if not os.path.isfile(mod_path):
+        return None
+    if mod_path in _loaded_modules:
+        return _loaded_modules[mod_path]
+    spec = importlib.util.spec_from_file_location('boop_mod_' + str(len(_loaded_modules)), mod_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    _loaded_modules[mod_path] = module
+    return module
+
+class State:
+    def __init__(self, data):
+        self.text = data.get('text')
+        self.fullText = data.get('fullText')
+        self.selection = data.get('selection')
+        self.network = data.get('network', False)
+        self.inserts = []
+        self.messages = []
+    def post_info(self, msg):
+        self.messages.append({'type': 'info', 'message': msg})
+    def post_error(self, msg):
+        self.messages.append({'type': 'error', 'message': msg})
+    def insert(self, value):
+        self.inserts.append(value)
+    def fetch(self, url, method=None, body=None):
+        if not self.network:
+            self.post_error('Network permission required')
+            return None
+        req = urllib.request.Request(url, data=body.encode('utf-8') if body else None, method=method or 'GET')
+        try:
+            with urllib.request.urlopen(req) as f:
+                return f.read().decode('utf-8')
+        except Exception:
+            self.post_error('Failed to fetch')
+            return None
+
+state_obj = State(state)
+
+globals()[require_name] = _boop_require
+if require_name != 'boop_require':
+    globals()['boop_require'] = _boop_require
+
+script_path = sys.argv[1]
+
+spec = importlib.util.spec_from_file_location('user_script', script_path)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+if hasattr(module, 'main'):
+    module.main(state_obj)
+
+output = {
+    'text': state_obj.text,
+    'fullText': state_obj.fullText,
+    'selection': state_obj.selection,
+    'inserts': state_obj.inserts,
+    'messages': state_obj.messages,
+}
+print(json.dumps(output))

--- a/Boop/Boop/bridges/ruby/bridge.rb
+++ b/Boop/Boop/bridges/ruby/bridge.rb
@@ -1,0 +1,93 @@
+require 'json'
+require 'open-uri'
+
+data = JSON.parse(ENV['BOOP_STATE'] || '{}')
+MODULE_EXT = ENV['BOOP_MODULE_EXT'] || '.rb'
+SCRIPT_DIR = ENV['BOOP_SCRIPT_DIR'] || ''
+LIB_DIR = ENV['BOOP_LIB_DIR'] || ''
+REQUIRE_NAME = ENV['BOOP_REQUIRE_NAME'] || 'boop_require'
+
+module Kernel
+  alias_method :_boop_native_require, :require
+  def boop_require_impl(path)
+    mod = path
+    mod += MODULE_EXT unless mod.end_with?(MODULE_EXT)
+    full = if mod.start_with?('@boop/')
+             File.join(LIB_DIR, mod[6..-1])
+           else
+             File.join(SCRIPT_DIR, mod)
+           end
+    if File.exist?(full)
+      load full
+      true
+    else
+      _boop_native_require(path)
+    end
+  end
+  module_function :boop_require_impl
+end
+
+Kernel.module_eval do
+  define_method(REQUIRE_NAME) { |p| boop_require_impl(p) }
+  module_function REQUIRE_NAME
+  if REQUIRE_NAME != 'boop_require'
+    define_method(:boop_require) { |p| boop_require_impl(p) }
+    module_function :boop_require
+  end
+end
+
+class State
+  attr_accessor :text, :fullText, :selection
+  def initialize(hash)
+    @text = hash['text']
+    @fullText = hash['fullText']
+    @selection = hash['selection']
+    @network = hash['network']
+    @inserts = []
+    @messages = []
+  end
+  def post_info(msg)
+    @messages << { 'type' => 'info', 'message' => msg }
+  end
+  def post_error(msg)
+    @messages << { 'type' => 'error', 'message' => msg }
+  end
+  def insert(val)
+    @inserts << val
+  end
+  def fetch(url, method=nil, body=nil)
+    unless @network
+      post_error('Network permission required')
+      return nil
+    end
+    begin
+      cmd = ['curl', '-sL']
+      cmd += ['-X', method] if method && method != 'GET'
+      cmd += ['--data', body.to_s] if body
+      cmd << url
+      IO.popen(cmd, 'r', &:read)
+    rescue
+      post_error('Failed to fetch')
+      nil
+    end
+  end
+  def to_h
+    {
+      'text' => @text,
+      'fullText' => @fullText,
+      'selection' => @selection,
+      'inserts' => @inserts,
+      'messages' => @messages
+    }
+  end
+end
+
+script_path = ARGV.shift
+
+state = State.new(data)
+load script_path
+if defined?(main)
+  main(state)
+end
+
+puts JSON.generate(state.to_h)

--- a/Boop/Boop/scripts/LuaCapitalize.lua
+++ b/Boop/Boop/scripts/LuaCapitalize.lua
@@ -1,0 +1,16 @@
+--[[
+{
+    "api": 1,
+    "name": "Lua Capitalize",
+    "description": "Capitalizes your text using Lua",
+    "author": "Codex",
+    "icon": "textformat",
+    "tags": "capitalize,lua"
+}
+]]
+
+function main(state)
+  if state.text then
+    state.text = string.upper(string.sub(state.text,1,1)) .. string.sub(state.text,2)
+  end
+end

--- a/Boop/Boop/scripts/NodeTrim.njs
+++ b/Boop/Boop/scripts/NodeTrim.njs
@@ -1,0 +1,15 @@
+/**
+{
+    "api": 1,
+    "name": "Node Trim",
+    "description": "Trims whitespace using Node.js",
+    "author": "Codex",
+    "icon": "scissors",
+    "tags": "trim,node"
+}
+*/
+exports.main = function(state){
+  if(state.text){
+    state.text = state.text.trim();
+  }
+};

--- a/Boop/Boop/scripts/PerlReverse.pl
+++ b/Boop/Boop/scripts/PerlReverse.pl
@@ -1,0 +1,16 @@
+# {
+#     "api": 1,
+#     "name": "Perl Reverse",
+#     "description": "Reverses your text using Perl",
+#     "author": "Codex",
+#     "icon": "rotate-left",
+#     "tags": "reverse,perl"
+# }
+
+sub main {
+    my ($state) = @_;
+    if ($state->{text}) {
+        $state->{text} = reverse $state->{text};
+    }
+}
+1;

--- a/Boop/Boop/scripts/PyUpcase.py
+++ b/Boop/Boop/scripts/PyUpcase.py
@@ -1,0 +1,14 @@
+"""
+{
+    "api": 1,
+    "name": "Python Upcase",
+    "description": "Converts your text to uppercase using Python.",
+    "author": "Codex",
+    "icon": "type",
+    "tags": "upcase,python"
+}
+"""
+
+def main(state):
+    if state.text:
+        state.text = state.text.upper()

--- a/Boop/Boop/scripts/RbDowncase.rb
+++ b/Boop/Boop/scripts/RbDowncase.rb
@@ -1,0 +1,16 @@
+#
+# {
+#     "api": 1,
+#     "name": "Ruby Downcase",
+#     "description": "Converts your text to lowercase using Ruby.",
+#     "author": "Codex",
+#     "icon": "type",
+#     "tags": "downcase,ruby"
+# }
+#
+
+def main(state)
+  if state.text
+    state.text = state.text.downcase
+  end
+end

--- a/Boop/Documentation/Modules.md
+++ b/Boop/Documentation/Modules.md
@@ -6,16 +6,17 @@ ___
 *<p align=center>Modules are available in Boop version 1.2.0 and above.</p>*
 ___
 
-Just to be very clear before we get started: **Boop does not support commonJS/node/ES6 modules**. It has a custom import system that may or may not be compatible with some existing modules.
+Just to be very clear before we get started: **Boop does not support commonJS/node/ES6 modules**. It has a custom import system that may or may not be compatible with some existing modules. The same mechanism is also exposed to Python, Ruby, Perl, Lua and Node.js bridges. In languages other than JavaScript and Node.js the import function defaults to `boop_require`. You can set a global override or per-runtime keyword in the Runtime preferences. The chosen keyword is passed to interpreters via the `BOOP_REQUIRE_NAME` environment variable.
 
 ## Importing modules
 
-To import a module, use the require function. It'll will return the contents of `module.exports`:
+To import a module, use the `require` function in JavaScript and Node.js, or the configured keyword (default `boop_require`) in Python, Ruby, Perl and Lua. It will return the contents of `module.exports`:
 
 ```javascript
 const test = require('lib/testLib')
 const test = require('modules/otherLib.js')
 ```
+// In Python/Ruby/Perl/Lua use `boop_require('lib/testLib')` (or your custom keyword)
 
 If you do not include a `.js` extension, the system will add one automatically.
 

--- a/Boop/Documentation/Readme.md
+++ b/Boop/Documentation/Readme.md
@@ -49,6 +49,13 @@ You can find more functions in the [Boop Script Repository](https://github.com/I
 ### Can I make my own scripts?
 
 Yes! Simply follow the instruction in the [Custom Scripts page](CustomScripts.md) to know how to get started.
+Scripts can also be written in Python, Ruby, Perl, Lua and Node.js via small bridge programs that expose the same API used in JavaScript. These interpreters exchange data through JSON in the `BOOP_STATE` environment variable.
+Modules can be imported with a special require function (default `boop_require`) in Python, Ruby, Perl and Lua. You can set a global or per-runtime keyword in the Runtime preferences. Node.js and JavaScript still use `require`.
+
+### Can scripts make network requests?
+
+Yes, but only if they declare the `network` permission in their metadata. When
+allowed, a script can call `state.fetch(url, method, body)` to synchronously download data or POST payloads.
 
 ### Does Boop collect data on me?
 
@@ -60,7 +67,7 @@ The best way to do that is to [file an issue on GitHub](https://github.com/IvanM
 
 ### How is Boop built?
 
-Boop is mostly built using a custom fork of [SavannaKit](https://github.com/IvanMathy/savannakit), originally created by [Louis D'hauwe](http://twitter.com/LouisDhauwe). The search is powered by a custom fork of [Fuse-swift](https://github.com/IvanMathy/fuse-swift). The rest of Boop is simply built in Swift, besides scripts which are Javascript. Go ahead and open some of them to check their license!
+Boop is mostly built using a custom fork of [SavannaKit](https://github.com/IvanMathy/savannakit), originally created by [Louis D'hauwe](http://twitter.com/LouisDhauwe). The search is powered by a custom fork of [Fuse-swift](https://github.com/IvanMathy/fuse-swift). The rest of Boop is simply built in Swift, besides scripts which are primarily JavaScript (but Python, Ruby, Perl, Lua and Node.js are supported too). Go ahead and open some of them to check their license!
 
 ### Do I have to say "Boop" out loud when I press ⌘+B?
 

--- a/Boop/UI/Preferences.storyboard
+++ b/Boop/UI/Preferences.storyboard
@@ -34,6 +34,7 @@
                     <tabViewItems>
                         <tabViewItem label="Scripts" identifier="" image="text.and.command.macwindow" catalog="system" id="drV-oE-7k3"/>
                         <tabViewItem label="Colors" image="paintpalette" catalog="system" id="OgA-dF-Ylu"/>
+                        <tabViewItem label="Runtimes" image="terminal" catalog="system" id="Q2u-lh-NBt"/>
                     </tabViewItems>
                     <tabView key="tabView" type="noTabsNoBorder" id="nRh-fE-4La">
                         <rect key="frame" x="0.0" y="0.0" width="450" height="300"/>
@@ -47,6 +48,7 @@
                         <outlet property="tabView" destination="nRh-fE-4La" id="Lf1-uB-6kn"/>
                         <segue destination="oGW-Ve-Lv5" kind="relationship" relationship="tabItems" id="EhK-SX-Eff"/>
                         <segue destination="dVd-GH-dN9" kind="relationship" relationship="tabItems" id="ZZr-kK-3rR"/>
+                        <segue destination="taR-nA-k0M" kind="relationship" relationship="tabItems" id="iEm-rV-VJ3"/>
                     </connections>
                 </tabViewController>
                 <customObject id="cp6-kM-xr4" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
@@ -289,6 +291,19 @@
                 <userDefaultsController representsSharedInstance="YES" id="l2g-ul-G9x"/>
             </objects>
             <point key="canvasLocation" x="386" y="722"/>
+        </scene>
+        <!--Runtimes-->
+        <scene sceneID="wkA-Rn-q0b">
+            <objects>
+                <viewController title="Runtimes" id="taR-nA-k0M" customClass="RuntimeSettingsViewController" customModule="Boop" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" id="RtM-vw-xL1">
+                        <rect key="frame" x="0.0" y="0.0" width="410" height="160"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </view>
+                </viewController>
+                <customObject id="bCs-hm-cO0" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="900" y="346"/>
         </scene>
     </scenes>
     <resources>


### PR DESCRIPTION
## Summary
- manage runtime paths and enable/disable interpreters through new RuntimeSettingsViewController
- overlay runtime short name onto script icons in search results
- store runtime enable/path prefs and skip disabled interpreters when loading scripts
- expose helper properties on `ScriptInterpreter`
- rename `require` helper to `boop_require` in Python, Ruby, Perl and Lua bridges
- document new `boop_require` usage across languages
- make `boop_require` keyword configurable via preferences and bridges
- allow per-runtime overrides of the keyword

## Testing
- `swiftc -parse Boop/Boop/System/Models/*.swift Boop/Boop/System/ScriptManager.swift`
- `BOOP_STATE='{"text":"hello"}' python3 Boop/Boop/bridges/python/bridge.py Boop/Boop/scripts/PyUpcase.py`
- `BOOP_STATE='{"text":"HELLO"}' ruby Boop/Boop/bridges/ruby/bridge.rb Boop/Boop/scripts/RbDowncase.rb`
- `BOOP_STATE='{"text":"abc"}' perl Boop/Boop/bridges/perl/bridge.pl Boop/Boop/scripts/PerlReverse.pl`
- `BOOP_STATE='{"text":" hello "}' node Boop/Boop/bridges/node/bridge.js Boop/Boop/scripts/NodeTrim.njs`
- `lua Boop/Boop/bridges/lua/bridge.lua Boop/Boop/scripts/LuaCapitalize.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68662928b90c832cb809d7ecefd7b231